### PR TITLE
Properly initialise streams member variable.

### DIFF
--- a/InfiniTAM/Engine/OpenNIEngine.cpp
+++ b/InfiniTAM/Engine/OpenNIEngine.cpp
@@ -13,7 +13,7 @@ using namespace InfiniTAM::Engine;
 
 class OpenNIEngine::PrivateData {
 	public:
-	PrivateData(void) {}
+	PrivateData(void) : streams(NULL) {}
 	openni::Device device;
 	openni::VideoStream depthStream, colorStream;
 


### PR DESCRIPTION
Make sure that the streams member variable in OpenNI::PrivateData is properly initialised to NULL - this makes it safe to delete[] when opening the OpenNI device fails.
