### PR TITLE
Fix the escape key switch case.

### DIFF
--- a/InfiniTAM/Engine/UIEngine.cpp
+++ b/InfiniTAM/Engine/UIEngine.cpp
@@ -174,7 +174,7 @@ void UIEngine::glutKeyUpFunction(unsigned char key, int x, int y)
 		}
 		break;
 	case 'e':
-	case '27': // esc key
+	case 27: // esc key
 		printf("exiting ...\n");
 		uiEngine->mainLoopAction = UIEngine::EXIT;
 		break;


### PR DESCRIPTION
/Users/stuart/programs/InfiniTAM/InfiniTAM/Engine/UIEngine.cpp:177:7: warning: 
      multi-character character constant [-Wmultichar]
        case '27': // esc key
             ^
/Users/stuart/programs/InfiniTAM/InfiniTAM/Engine/UIEngine.cpp:177:7: warning: 
      overflow converting case value to switch condition type (12855 to 55)
      [-Wswitch]
2 warnings generated.
