### PR TITLE
Add librealsense support to RealSenseEngine

### DIFF
--- a/InfiniTAM/Engine/RealSenseEngine.h
+++ b/InfiniTAM/Engine/RealSenseEngine.h
@@ -24,7 +24,7 @@ namespace InfiniTAM
 
 			Vector2i imageSize_rgb, imageSize_d;
 		public:
-			RealSenseEngine(const char *calibFilename, Vector2i imageSize_rgb = Vector2i(1920, 1080), Vector2i imageSize_d = Vector2i(628, 468));
+			RealSenseEngine(const char *calibFilename, Vector2i imageSize_rgb = Vector2i(640, 480), Vector2i imageSize_d = Vector2i(640, 480));
 			~RealSenseEngine();
 
 			bool hasMoreImages(void);

--- a/InfiniTAM/cmake/UseRealSense.cmake
+++ b/InfiniTAM/cmake/UseRealSense.cmake
@@ -5,9 +5,9 @@
 OPTION(WITH_REALSENSE "Build with Intel RealSense support?" OFF)
 
 IF(MSVC_IDE AND WITH_REALSENSE)
-  FIND_PATH(RealSense_ROOT attributions.rtf HINTS "C:/Program Files (x86)/Intel/RSSDK")
-  FIND_PATH(RealSense_INCLUDE_DIR pxcsensemanager.h HINTS "${RealSense_ROOT}/include")
-  FIND_LIBRARY(RealSense_LIBRARY libpxc HINTS "${RealSense_ROOT}/lib/x64")
+  FIND_PATH(RealSense_ROOT librealsense.vc12 HINTS "D:/Develop/intel/librealsense")
+  FIND_PATH(RealSense_INCLUDE_DIR librealsense HINTS "${RealSense_ROOT}/include")
+  FIND_LIBRARY(RealSense_LIBRARY realsense HINTS "${RealSense_ROOT}/bin/x64")
 ENDIF()
 
 INCLUDE_DIRECTORIES(${RealSense_INCLUDE_DIR})


### PR DESCRIPTION
Adds support for the new [librealsense library](https://github.com/IntelRealSense/librealsense). 

* Tested with the R200 Intel camera.
* Removes prior sdk support.
* Adds color support to the RealSenseEngine.