### PR TITLE
Add support of RealSense SDK 2.0

### DIFF
--- a/InfiniTAM/Apps/InfiniTAM/CMakeLists.txt
+++ b/InfiniTAM/Apps/InfiniTAM/CMakeLists.txt
@@ -21,6 +21,7 @@ INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseOpenMP.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseOpenNI.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UsePNG.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseRealSense.cmake)
+INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseRealSense2.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseUVC.cmake)
 
 #############################
@@ -60,4 +61,5 @@ INCLUDE(${PROJECT_SOURCE_DIR}/cmake/LinkOpenGL.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/LinkOpenNI.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/LinkPNG.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/LinkRealSense.cmake)
+INCLUDE(${PROJECT_SOURCE_DIR}/cmake/LinkRealSense2.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/LinkUVC.cmake)

--- a/InfiniTAM/Apps/InfiniTAM/InfiniTAM.cpp
+++ b/InfiniTAM/Apps/InfiniTAM/InfiniTAM.cpp
@@ -11,7 +11,7 @@
 #include "../../InputSource/PicoFlexxEngine.h"
 #include "../../InputSource/RealSenseEngine.h"
 #include "../../InputSource/LibUVCEngine.h"
-#include "../../InputSource/RealSenseEngine.h"
+#include "../../InputSource/RealSense2Engine.h"
 #include "../../InputSource/FFMPEGReader.h"
 #include "../../ITMLib/ITMLibDefines.h"
 #include "../../ITMLib/Core/ITMBasicEngine.h"
@@ -116,7 +116,18 @@ static void CreateDefaultImageSource(ImageSourceEngine* & imageSource, IMUSource
 		}
 	}
 
-	if (imageSource == NULL)
+    if (imageSource == NULL)
+    {
+        printf("trying RealSense device with SDK 2.X (librealsense2)\n");
+        imageSource = new RealSense2Engine(calibFile);
+        if (imageSource->getDepthImageSize().x == 0)
+        {
+            delete imageSource;
+            imageSource = NULL;
+        }
+    }
+
+    if (imageSource == NULL)
 	{
 		printf("trying MS Kinect 2 device\n");
 		imageSource = new Kinect2Engine(calibFile);

--- a/InfiniTAM/Apps/InfiniTAM_cli/CMakeLists.txt
+++ b/InfiniTAM/Apps/InfiniTAM_cli/CMakeLists.txt
@@ -17,6 +17,7 @@ INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseOpenMP.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseOpenNI.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UsePNG.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseRealSense.cmake)
+INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseRealSense2.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseUVC.cmake)
 
 #############################
@@ -52,4 +53,5 @@ TARGET_LINK_LIBRARIES(${targetname} InputSource ITMLib MiniSlamGraphLib ORUtils 
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/LinkOpenNI.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/LinkPNG.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/LinkRealSense.cmake)
+INCLUDE(${PROJECT_SOURCE_DIR}/cmake/LinkRealSense2.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/LinkUVC.cmake)

--- a/InfiniTAM/InputSource/CMakeLists.txt
+++ b/InfiniTAM/InputSource/CMakeLists.txt
@@ -27,6 +27,7 @@ INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseOpenGL.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseOpenMP.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseOpenNI.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseRealSense.cmake)
+INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseRealSense2.cmake)
 INCLUDE(${PROJECT_SOURCE_DIR}/cmake/UseUVC.cmake)
 
 #############################
@@ -44,6 +45,7 @@ LibUVCEngine.cpp
 OpenNIEngine.cpp
 PicoFlexxEngine.cpp
 RealSenseEngine.cpp
+RealSense2Engine.cpp
 )
 
 SET(headers
@@ -57,6 +59,7 @@ LibUVCEngine.h
 OpenNIEngine.h
 PicoFlexxEngine.h
 RealSenseEngine.h
+RealSense2Engine.h
 )
 
 #############################

--- a/InfiniTAM/InputSource/RealSense2Engine.cpp
+++ b/InfiniTAM/InputSource/RealSense2Engine.cpp
@@ -18,106 +18,106 @@ using namespace ITMLib;
 
 static void print_device_information(const rs2::device& dev)
 {
-    // Each device provides some information on itself
-    // The different types of available information are represented using the "RS2_CAMERA_INFO_*" enum
-    
-    std::cout << "Device information: " << std::endl;
-    //The following code shows how to enumerate all of the RS2_CAMERA_INFO
-    //Note that all enum types in the SDK start with the value of zero and end at the "*_COUNT" value
-    for (int i = 0; i < static_cast<int>(RS2_CAMERA_INFO_COUNT); i++)
-    {
-        rs2_camera_info info_type = static_cast<rs2_camera_info>(i);
-        //SDK enum types can be streamed to get a string that represents them
-        std::cout << "  " << std::left << std::setw(20) << info_type << " : ";
-        
-        //A device might not support all types of RS2_CAMERA_INFO.
-        //To prevent throwing exceptions from the "get_info" method we first check if the device supports this type of info
-        if (dev.supports(info_type))
-            std::cout << dev.get_info(info_type) << std::endl;
-        else
-            std::cout << "N/A" << std::endl;
-    }
+	// Each device provides some information on itself
+	// The different types of available information are represented using the "RS2_CAMERA_INFO_*" enum
+	
+	std::cout << "Device information: " << std::endl;
+	//The following code shows how to enumerate all of the RS2_CAMERA_INFO
+	//Note that all enum types in the SDK start with the value of zero and end at the "*_COUNT" value
+	for (int i = 0; i < static_cast<int>(RS2_CAMERA_INFO_COUNT); i++)
+	{
+		rs2_camera_info info_type = static_cast<rs2_camera_info>(i);
+		//SDK enum types can be streamed to get a string that represents them
+		std::cout << "  " << std::left << std::setw(20) << info_type << " : ";
+		
+		//A device might not support all types of RS2_CAMERA_INFO.
+		//To prevent throwing exceptions from the "get_info" method we first check if the device supports this type of info
+		if (dev.supports(info_type))
+			std::cout << dev.get_info(info_type) << std::endl;
+		else
+			std::cout << "N/A" << std::endl;
+	}
 }
 
 
 RealSense2Engine::RealSense2Engine(const char *calibFilename, bool alignColourWithDepth,
-                                 Vector2i requested_imageSize_rgb, Vector2i requested_imageSize_d)
+								   Vector2i requested_imageSize_rgb, Vector2i requested_imageSize_d)
 : BaseImageSourceEngine(calibFilename)
 {
 	this->calib.disparityCalib.SetStandard();
 	this->calib.trafo_rgb_to_depth = ITMExtrinsics();
 	this->calib.intrinsics_d = this->calib.intrinsics_rgb;
-
+	
 	this->imageSize_d = requested_imageSize_d;
 	this->imageSize_rgb = requested_imageSize_rgb;
-
+	
 	this->ctx = std::unique_ptr<rs2::context>(new rs2::context());
-
+	
 	rs2::device_list availableDevices = ctx->query_devices();
-
+	
 	printf("There are %d connected RealSense devices.\n", availableDevices.size());
 	if (availableDevices.size() == 0) {
 		dataAvailable = false;
 		ctx.reset();
 		return;
 	}
-
+	
 	this->device = std::unique_ptr<rs2::device>(new rs2::device(availableDevices.front()));
-
+	
 	print_device_information(*device);
-
+	
 	this->pipe = std::unique_ptr<rs2::pipeline>(new rs2::pipeline(*ctx));
-
+	
 	rs2::config config;
 	config.enable_stream(RS2_STREAM_DEPTH, imageSize_d.x, imageSize_d.y, RS2_FORMAT_Z16, 30);
 	config.enable_stream(RS2_STREAM_COLOR, imageSize_rgb.x, imageSize_rgb.y, RS2_FORMAT_RGBA8, 30);
-
-    auto availableSensors = device->query_sensors();
-    std::cout << "Device consists of " << availableSensors.size() << " sensors:" << std::endl;
-    for (rs2::sensor sensor : availableSensors) {
-        //print_sensor_information(sensor);
-        
-        if (rs2::depth_sensor dpt_sensor = sensor.as<rs2::depth_sensor>()) {
-            float scale = dpt_sensor.get_depth_scale();
-            std::cout << "Scale factor for depth sensor is: " << scale << std::endl;
-            this->calib.disparityCalib.SetFrom(scale, 0, ITMLib::ITMDisparityCalib::TRAFO_AFFINE);
-        }
-    }
-    
+	
+	auto availableSensors = device->query_sensors();
+	std::cout << "Device consists of " << availableSensors.size() << " sensors:" << std::endl;
+	for (rs2::sensor sensor : availableSensors) {
+		//print_sensor_information(sensor);
+		
+		if (rs2::depth_sensor dpt_sensor = sensor.as<rs2::depth_sensor>()) {
+			float scale = dpt_sensor.get_depth_scale();
+			std::cout << "Scale factor for depth sensor is: " << scale << std::endl;
+			this->calib.disparityCalib.SetFrom(scale, 0, ITMLib::ITMDisparityCalib::TRAFO_AFFINE);
+		}
+	}
+	
 	rs2::pipeline_profile pipeline_profile = pipe->start(config);
-    
-    rs2::video_stream_profile depth_stream_profile = pipeline_profile.get_stream(RS2_STREAM_DEPTH).as<rs2::video_stream_profile>();
-    rs2::video_stream_profile color_stream_profile = pipeline_profile.get_stream(RS2_STREAM_COLOR).as<rs2::video_stream_profile>();
-    
-    // - intrinsics
-    rs2_intrinsics intrinsics_depth = depth_stream_profile.get_intrinsics();
-    rs2_intrinsics intrinsics_rgb = color_stream_profile.get_intrinsics();
-    
-    this->calib.intrinsics_d.projectionParamsSimple.fx = intrinsics_depth.fx;
-    this->calib.intrinsics_d.projectionParamsSimple.fy = intrinsics_depth.fy;
-    this->calib.intrinsics_d.projectionParamsSimple.px = intrinsics_depth.ppx;
-    this->calib.intrinsics_d.projectionParamsSimple.py = intrinsics_depth.ppy;
-    
-    this->calib.intrinsics_rgb.projectionParamsSimple.fx = intrinsics_rgb.fx;
-    this->calib.intrinsics_rgb.projectionParamsSimple.fy = intrinsics_rgb.fy;
-    this->calib.intrinsics_rgb.projectionParamsSimple.px = intrinsics_rgb.ppx;
-    this->calib.intrinsics_rgb.projectionParamsSimple.py = intrinsics_rgb.ppy;
-    
-    // - extrinsics
-    rs2_extrinsics rs_extrinsics = color_stream_profile.get_extrinsics_to(depth_stream_profile);
-    
-    Matrix4f extrinsics;
-    extrinsics.m00 = rs_extrinsics.rotation[0]; extrinsics.m10 = rs_extrinsics.rotation[1]; extrinsics.m20 = rs_extrinsics.rotation[2];
-    extrinsics.m01 = rs_extrinsics.rotation[3]; extrinsics.m11 = rs_extrinsics.rotation[4]; extrinsics.m21 = rs_extrinsics.rotation[5];
-    extrinsics.m02 = rs_extrinsics.rotation[6]; extrinsics.m12 = rs_extrinsics.rotation[7]; extrinsics.m22 = rs_extrinsics.rotation[8];
-    extrinsics.m30 = rs_extrinsics.translation[0];
-    extrinsics.m31 = rs_extrinsics.translation[1];
-    extrinsics.m32 = rs_extrinsics.translation[2];
-    
-    extrinsics.m33 = 1.0f;
-    extrinsics.m03 = 0.0f; extrinsics.m13 = 0.0f; extrinsics.m23 = 0.0f;
-    
-    this->calib.trafo_rgb_to_depth.SetFrom(extrinsics);
+	
+	rs2::video_stream_profile depth_stream_profile = pipeline_profile.get_stream(RS2_STREAM_DEPTH).as<rs2::video_stream_profile>();
+	rs2::video_stream_profile color_stream_profile = pipeline_profile.get_stream(RS2_STREAM_COLOR).as<rs2::video_stream_profile>();
+	
+	// - intrinsics
+	rs2_intrinsics intrinsics_depth = depth_stream_profile.get_intrinsics();
+	rs2_intrinsics intrinsics_rgb = color_stream_profile.get_intrinsics();
+	
+	this->calib.intrinsics_d.projectionParamsSimple.fx = intrinsics_depth.fx;
+	this->calib.intrinsics_d.projectionParamsSimple.fy = intrinsics_depth.fy;
+	this->calib.intrinsics_d.projectionParamsSimple.px = intrinsics_depth.ppx;
+	this->calib.intrinsics_d.projectionParamsSimple.py = intrinsics_depth.ppy;
+	
+	this->calib.intrinsics_rgb.projectionParamsSimple.fx = intrinsics_rgb.fx;
+	this->calib.intrinsics_rgb.projectionParamsSimple.fy = intrinsics_rgb.fy;
+	this->calib.intrinsics_rgb.projectionParamsSimple.px = intrinsics_rgb.ppx;
+	this->calib.intrinsics_rgb.projectionParamsSimple.py = intrinsics_rgb.ppy;
+	
+	// - extrinsics
+	rs2_extrinsics rs_extrinsics = color_stream_profile.get_extrinsics_to(depth_stream_profile);
+	
+	Matrix4f extrinsics;
+	extrinsics.m00 = rs_extrinsics.rotation[0]; extrinsics.m10 = rs_extrinsics.rotation[1]; extrinsics.m20 = rs_extrinsics.rotation[2];
+	extrinsics.m01 = rs_extrinsics.rotation[3]; extrinsics.m11 = rs_extrinsics.rotation[4]; extrinsics.m21 = rs_extrinsics.rotation[5];
+	extrinsics.m02 = rs_extrinsics.rotation[6]; extrinsics.m12 = rs_extrinsics.rotation[7]; extrinsics.m22 = rs_extrinsics.rotation[8];
+	extrinsics.m30 = rs_extrinsics.translation[0];
+	extrinsics.m31 = rs_extrinsics.translation[1];
+	extrinsics.m32 = rs_extrinsics.translation[2];
+	
+	extrinsics.m33 = 1.0f;
+	extrinsics.m03 = 0.0f; extrinsics.m13 = 0.0f; extrinsics.m23 = 0.0f;
+	
+	this->calib.trafo_rgb_to_depth.SetFrom(extrinsics);
 }
 
 RealSense2Engine::~RealSense2Engine()
@@ -130,29 +130,29 @@ RealSense2Engine::~RealSense2Engine()
 void RealSense2Engine::getImages(ITMUChar4Image *rgbImage, ITMShortImage *rawDepthImage)
 {
 	dataAvailable = false;
-
+	
 	// get frames
 	rs2::frameset frames = pipe->wait_for_frames();
-
+	
 	rs2::depth_frame depth = frames.get_depth_frame();
 	rs2::video_frame color = frames.get_color_frame();
-
-    constexpr size_t rgb_pixel_size = sizeof(Vector4u);
-    static_assert(4 == rgb_pixel_size, "sizeof(rgb pixel) must equal 4");
-    const Vector4u * color_frame = reinterpret_cast<const Vector4u*>(color.get_data());
-    
-    constexpr size_t depth_pixel_size = sizeof(uint16_t);
-    static_assert(2 == depth_pixel_size, "sizeof(depth pixel) must equal 2");
+	
+	constexpr size_t rgb_pixel_size = sizeof(Vector4u);
+	static_assert(4 == rgb_pixel_size, "sizeof(rgb pixel) must equal 4");
+	const Vector4u * color_frame = reinterpret_cast<const Vector4u*>(color.get_data());
+	
+	constexpr size_t depth_pixel_size = sizeof(uint16_t);
+	static_assert(2 == depth_pixel_size, "sizeof(depth pixel) must equal 2");
 	auto depth_frame = reinterpret_cast<const uint16_t *>(depth.get_data());
-
+	
 	// setup infinitam frames
 	short *rawDepth = rawDepthImage->GetData(MEMORYDEVICE_CPU);
 	Vector4u *rgb = rgbImage->GetData(MEMORYDEVICE_CPU);
-    
-    // Let's just memcpy the data instead of using loops
-    std::memcpy(rgb, color_frame, rgb_pixel_size * rgbImage->noDims.x*rgbImage->noDims.y);
-    std::memcpy(rawDepth, depth_frame, depth_pixel_size * rawDepthImage->noDims.x * rawDepthImage->noDims.y);
-    
+	
+	// Let's just memcpy the data instead of using loops
+	std::memcpy(rgb, color_frame, rgb_pixel_size * rgbImage->noDims.x*rgbImage->noDims.y);
+	std::memcpy(rawDepth, depth_frame, depth_pixel_size * rawDepthImage->noDims.x * rawDepthImage->noDims.y);
+	
 	dataAvailable = true;
 }
 
@@ -173,7 +173,7 @@ Vector2i RealSense2Engine::getRGBImageSize(void) const {
 using namespace InputSource;
 
 RealSense2Engine::RealSense2Engine(const char *calibFilename, bool alignColourWithDepth,
-                                 Vector2i requested_imageSize_rgb, Vector2i requested_imageSize_d)
+								   Vector2i requested_imageSize_rgb, Vector2i requested_imageSize_d)
 : BaseImageSourceEngine(calibFilename)
 {
 	printf("compiled without RealSense SDK 2.X support\n");

--- a/InfiniTAM/InputSource/RealSense2Engine.cpp
+++ b/InfiniTAM/InputSource/RealSense2Engine.cpp
@@ -1,0 +1,194 @@
+// Copyright 2014-2017 Oxford University Innovation Limited and the authors of InfiniTAM
+
+#include "RealSense2Engine.h"
+
+#include "../ORUtils/FileUtils.h"
+
+#include <cstdio>
+#include <stdexcept>
+
+#include <iostream>
+#include <iomanip>
+
+#ifdef COMPILE_WITH_RealSense2
+#include "librealsense2/rs.hpp"
+
+using namespace InputSource;
+using namespace ITMLib;
+
+static void print_device_information(const rs2::device& dev)
+{
+    // Each device provides some information on itself
+    // The different types of available information are represented using the "RS2_CAMERA_INFO_*" enum
+    
+    std::cout << "Device information: " << std::endl;
+    //The following code shows how to enumerate all of the RS2_CAMERA_INFO
+    //Note that all enum types in the SDK start with the value of zero and end at the "*_COUNT" value
+    for (int i = 0; i < static_cast<int>(RS2_CAMERA_INFO_COUNT); i++)
+    {
+        rs2_camera_info info_type = static_cast<rs2_camera_info>(i);
+        //SDK enum types can be streamed to get a string that represents them
+        std::cout << "  " << std::left << std::setw(20) << info_type << " : ";
+        
+        //A device might not support all types of RS2_CAMERA_INFO.
+        //To prevent throwing exceptions from the "get_info" method we first check if the device supports this type of info
+        if (dev.supports(info_type))
+            std::cout << dev.get_info(info_type) << std::endl;
+        else
+            std::cout << "N/A" << std::endl;
+    }
+}
+
+
+RealSense2Engine::RealSense2Engine(const char *calibFilename, bool alignColourWithDepth,
+                                 Vector2i requested_imageSize_rgb, Vector2i requested_imageSize_d)
+: BaseImageSourceEngine(calibFilename)
+{
+	this->calib.disparityCalib.SetStandard();
+	this->calib.trafo_rgb_to_depth = ITMExtrinsics();
+	this->calib.intrinsics_d = this->calib.intrinsics_rgb;
+
+	this->imageSize_d = requested_imageSize_d;
+	this->imageSize_rgb = requested_imageSize_rgb;
+
+	this->ctx = std::unique_ptr<rs2::context>(new rs2::context());
+
+	rs2::device_list availableDevices = ctx->query_devices();
+
+	printf("There are %d connected RealSense devices.\n", availableDevices.size());
+	if (availableDevices.size() == 0) {
+		dataAvailable = false;
+		ctx.reset();
+		return;
+	}
+
+	this->device = std::unique_ptr<rs2::device>(new rs2::device(availableDevices.front()));
+
+	print_device_information(*device);
+
+	this->pipe = std::unique_ptr<rs2::pipeline>(new rs2::pipeline(*ctx));
+
+	rs2::config config;
+	config.enable_stream(RS2_STREAM_DEPTH, imageSize_d.x, imageSize_d.y, RS2_FORMAT_Z16, 30);
+	config.enable_stream(RS2_STREAM_COLOR, imageSize_rgb.x, imageSize_rgb.y, RS2_FORMAT_RGBA8, 30);
+
+    auto availableSensors = device->query_sensors();
+    std::cout << "Device consists of " << availableSensors.size() << " sensors:" << std::endl;
+    for (rs2::sensor sensor : availableSensors) {
+        //print_sensor_information(sensor);
+        
+        if (rs2::depth_sensor dpt_sensor = sensor.as<rs2::depth_sensor>()) {
+            float scale = dpt_sensor.get_depth_scale();
+            std::cout << "Scale factor for depth sensor is: " << scale << std::endl;
+            this->calib.disparityCalib.SetFrom(scale, 0, ITMLib::ITMDisparityCalib::TRAFO_AFFINE);
+        }
+    }
+    
+	rs2::pipeline_profile pipeline_profile = pipe->start(config);
+    
+    rs2::video_stream_profile depth_stream_profile = pipeline_profile.get_stream(RS2_STREAM_DEPTH).as<rs2::video_stream_profile>();
+    rs2::video_stream_profile color_stream_profile = pipeline_profile.get_stream(RS2_STREAM_COLOR).as<rs2::video_stream_profile>();
+    
+    // - intrinsics
+    rs2_intrinsics intrinsics_depth = depth_stream_profile.get_intrinsics();
+    rs2_intrinsics intrinsics_rgb = color_stream_profile.get_intrinsics();
+    
+    this->calib.intrinsics_d.projectionParamsSimple.fx = intrinsics_depth.fx;
+    this->calib.intrinsics_d.projectionParamsSimple.fy = intrinsics_depth.fy;
+    this->calib.intrinsics_d.projectionParamsSimple.px = intrinsics_depth.ppx;
+    this->calib.intrinsics_d.projectionParamsSimple.py = intrinsics_depth.ppy;
+    
+    this->calib.intrinsics_rgb.projectionParamsSimple.fx = intrinsics_rgb.fx;
+    this->calib.intrinsics_rgb.projectionParamsSimple.fy = intrinsics_rgb.fy;
+    this->calib.intrinsics_rgb.projectionParamsSimple.px = intrinsics_rgb.ppx;
+    this->calib.intrinsics_rgb.projectionParamsSimple.py = intrinsics_rgb.ppy;
+    
+    // - extrinsics
+    rs2_extrinsics rs_extrinsics = color_stream_profile.get_extrinsics_to(depth_stream_profile);
+    
+    Matrix4f extrinsics;
+    extrinsics.m00 = rs_extrinsics.rotation[0]; extrinsics.m10 = rs_extrinsics.rotation[1]; extrinsics.m20 = rs_extrinsics.rotation[2];
+    extrinsics.m01 = rs_extrinsics.rotation[3]; extrinsics.m11 = rs_extrinsics.rotation[4]; extrinsics.m21 = rs_extrinsics.rotation[5];
+    extrinsics.m02 = rs_extrinsics.rotation[6]; extrinsics.m12 = rs_extrinsics.rotation[7]; extrinsics.m22 = rs_extrinsics.rotation[8];
+    extrinsics.m30 = rs_extrinsics.translation[0];
+    extrinsics.m31 = rs_extrinsics.translation[1];
+    extrinsics.m32 = rs_extrinsics.translation[2];
+    
+    extrinsics.m33 = 1.0f;
+    extrinsics.m03 = 0.0f; extrinsics.m13 = 0.0f; extrinsics.m23 = 0.0f;
+    
+    this->calib.trafo_rgb_to_depth.SetFrom(extrinsics);
+}
+
+RealSense2Engine::~RealSense2Engine()
+{
+	if (pipe) {
+		pipe->stop();
+	}
+}
+
+void RealSense2Engine::getImages(ITMUChar4Image *rgbImage, ITMShortImage *rawDepthImage)
+{
+	dataAvailable = false;
+
+	// get frames
+	rs2::frameset frames = pipe->wait_for_frames();
+
+	rs2::depth_frame depth = frames.get_depth_frame();
+	rs2::video_frame color = frames.get_color_frame();
+
+    constexpr size_t rgb_pixel_size = sizeof(Vector4u);
+    static_assert(4 == rgb_pixel_size, "sizeof(rgb pixel) must equal 4");
+    //const Vector4u * color_frame = reinterpret_cast<const Vector4u*>(color.get_data());
+    auto color_frame = reinterpret_cast<const char*>(color.get_data());
+    
+    constexpr size_t depth_pixel_size = sizeof(uint16_t);
+    static_assert(2 == depth_pixel_size, "sizeof(depth pixel) must equal 2");
+	auto depth_frame = reinterpret_cast<const uint16_t *>(depth.get_data());
+
+	// setup infinitam frames
+	short *rawDepth = rawDepthImage->GetData(MEMORYDEVICE_CPU);
+	Vector4u *rgb = rgbImage->GetData(MEMORYDEVICE_CPU);
+    
+    // Let's just memcpy the data instead of using loops
+    std::memcpy(rgb, color_frame, rgb_pixel_size * rgbImage->noDims.x*rgbImage->noDims.y);
+    std::memcpy(rawDepth, depth_frame, depth_pixel_size * rawDepthImage->noDims.x * rawDepthImage->noDims.y);
+    
+	dataAvailable = true;
+}
+
+bool RealSense2Engine::hasMoreImages(void) const {
+	return pipe != nullptr;
+}
+
+Vector2i RealSense2Engine::getDepthImageSize(void) const {
+	return pipe ? imageSize_d : Vector2i(0,0);
+}
+
+Vector2i RealSense2Engine::getRGBImageSize(void) const {
+	return pipe ? imageSize_rgb : Vector2i(0,0);
+}
+
+#else
+
+using namespace InputSource;
+
+RealSense2Engine::RealSense2Engine(const char *calibFilename, bool alignColourWithDepth,
+                                 Vector2i requested_imageSize_rgb, Vector2i requested_imageSize_d)
+: BaseImageSourceEngine(calibFilename)
+{
+	printf("compiled without RealSense SDK 2.X support\n");
+}
+RealSense2Engine::~RealSense2Engine()
+{}
+void RealSense2Engine::getImages(ITMUChar4Image *rgbImage, ITMShortImage *rawDepthImage)
+{ return; }
+bool RealSense2Engine::hasMoreImages(void) const
+{ return false; }
+Vector2i RealSense2Engine::getDepthImageSize(void) const
+{ return Vector2i(0,0); }
+Vector2i RealSense2Engine::getRGBImageSize(void) const
+{ return Vector2i(0,0); }
+
+#endif
+

--- a/InfiniTAM/InputSource/RealSense2Engine.cpp
+++ b/InfiniTAM/InputSource/RealSense2Engine.cpp
@@ -139,8 +139,7 @@ void RealSense2Engine::getImages(ITMUChar4Image *rgbImage, ITMShortImage *rawDep
 
     constexpr size_t rgb_pixel_size = sizeof(Vector4u);
     static_assert(4 == rgb_pixel_size, "sizeof(rgb pixel) must equal 4");
-    //const Vector4u * color_frame = reinterpret_cast<const Vector4u*>(color.get_data());
-    auto color_frame = reinterpret_cast<const char*>(color.get_data());
+    const Vector4u * color_frame = reinterpret_cast<const Vector4u*>(color.get_data());
     
     constexpr size_t depth_pixel_size = sizeof(uint16_t);
     static_assert(2 == depth_pixel_size, "sizeof(depth pixel) must equal 2");

--- a/InfiniTAM/InputSource/RealSense2Engine.h
+++ b/InfiniTAM/InputSource/RealSense2Engine.h
@@ -7,26 +7,27 @@
 namespace rs2 { class pipeline; class context; class device; }
 
 namespace InputSource {
-
-    class RealSense2Engine : public BaseImageSourceEngine
-    {
-    private:
-        bool dataAvailable;
-        std::unique_ptr<rs2::context> ctx;
-        std::unique_ptr<rs2::device> device;
-        std::unique_ptr<rs2::pipeline> pipe;
-        
-        Vector2i imageSize_rgb, imageSize_d;
-        
-    public:
-        RealSense2Engine(const char *calibFilename, bool alignColourWithDepth = true,
-                         Vector2i imageSize_rgb = Vector2i(640, 480), Vector2i imageSize_d = Vector2i(640, 480));
-        ~RealSense2Engine();
-        
-        bool hasMoreImages(void) const;
-        void getImages(ITMUChar4Image *rgb, ITMShortImage *rawDepth);
-        Vector2i getDepthImageSize(void) const;
-        Vector2i getRGBImageSize(void) const;
-    };
-
+	
+	class RealSense2Engine : public BaseImageSourceEngine
+	{
+	private:
+		bool dataAvailable;
+		std::unique_ptr<rs2::context> ctx;
+		std::unique_ptr<rs2::device> device;
+		std::unique_ptr<rs2::pipeline> pipe;
+		
+		Vector2i imageSize_rgb, imageSize_d;
+		
+	public:
+		RealSense2Engine(const char *calibFilename, bool alignColourWithDepth = true,
+						 Vector2i imageSize_rgb = Vector2i(640, 480), Vector2i imageSize_d = Vector2i(640, 480));
+		~RealSense2Engine();
+		
+		bool hasMoreImages(void) const;
+		void getImages(ITMUChar4Image *rgb, ITMShortImage *rawDepth);
+		Vector2i getDepthImageSize(void) const;
+		Vector2i getRGBImageSize(void) const;
+	};
+	
 }
+

--- a/InfiniTAM/InputSource/RealSense2Engine.h
+++ b/InfiniTAM/InputSource/RealSense2Engine.h
@@ -1,0 +1,32 @@
+// Copyright Oxford University Innovation Limited and the authors of InfiniTAM
+
+#pragma once
+
+#include "ImageSourceEngine.h"
+
+namespace rs2 { class pipeline; class context; class device; }
+
+namespace InputSource {
+
+    class RealSense2Engine : public BaseImageSourceEngine
+    {
+    private:
+        bool dataAvailable;
+        std::unique_ptr<rs2::context> ctx;
+        std::unique_ptr<rs2::device> device;
+        std::unique_ptr<rs2::pipeline> pipe;
+        
+        Vector2i imageSize_rgb, imageSize_d;
+        
+    public:
+        RealSense2Engine(const char *calibFilename, bool alignColourWithDepth = true,
+                         Vector2i imageSize_rgb = Vector2i(640, 480), Vector2i imageSize_d = Vector2i(640, 480));
+        ~RealSense2Engine();
+        
+        bool hasMoreImages(void) const;
+        void getImages(ITMUChar4Image *rgb, ITMShortImage *rawDepth);
+        Vector2i getDepthImageSize(void) const;
+        Vector2i getRGBImageSize(void) const;
+    };
+
+}

--- a/InfiniTAM/cmake/FindRealSense2.cmake
+++ b/InfiniTAM/cmake/FindRealSense2.cmake
@@ -1,0 +1,18 @@
+
+
+SET(REALSENSE2_ROOT "/usr/local" CACHE FILEPATH "Root directory of librealsense")
+
+FIND_PATH(RealSense2_INCLUDE_DIR librealsense2/rs.hpp HINTS "${REALSENSE2_ROOT}/include")
+FIND_LIBRARY(RealSense2_LIBRARY librealsense2 HINTS "${REALSENSE2_ROOT}/lib" "${REALSENSE2_ROOT}/lib/librealsense2.dylib")
+
+# handle the QUIETLY and REQUIRED arguments and set REALSENSE2_FOUND to TRUE if
+# all listed variables are TRUE
+#include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+#include(${CMAKE_MODULE_PATH}/FindPackageHandleStandardArgs.cmake)
+find_package_handle_standard_args(RealSense2 DEFAULT_MSG RealSense2_LIBRARY RealSense2_INCLUDE_DIR)
+
+#if(OPENNI_FOUND)
+#  set(OpenNI_LIBRARIES ${OpenNI_LIBRARY})
+#endif()
+
+MARK_AS_ADVANCED(RealSense2_LIBRARY RealSense2_INCLUDE_DIR)

--- a/InfiniTAM/cmake/LinkRealSense2.cmake
+++ b/InfiniTAM/cmake/LinkRealSense2.cmake
@@ -1,0 +1,7 @@
+########################
+# LinkRealSense2.cmake #
+########################
+
+IF(WITH_REALSENSE2)
+  TARGET_LINK_LIBRARIES(${targetname} ${RealSense2_LIBRARY})
+ENDIF()

--- a/InfiniTAM/cmake/UseRealSense2.cmake
+++ b/InfiniTAM/cmake/UseRealSense2.cmake
@@ -1,0 +1,11 @@
+#######################
+# UseRealSense2.cmake #
+#######################
+
+OPTION(WITH_REALSENSE2 "Build with Intel RealSense SDK 2 support?" OFF)
+
+IF(WITH_REALSENSE2)
+  FIND_PACKAGE(RealSense2 REQUIRED)
+  INCLUDE_DIRECTORIES(${RealSense2_INCLUDE_DIR})
+  ADD_DEFINITIONS(-DCOMPILE_WITH_RealSense2)
+ENDIF()

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Several 3rd party libraries are needed for compiling InfiniTAM. The given versio
     OPTIONAL, allows to get live images from Intel Realsense cameras
     available at https://github.com/IntelRealSense/librealsense
 
+  - librealsense2 (e.g. Intel® RealSense™ SDK 2.X)
+    OPTIONAL, allows to get live images from Intel Realsense cameras
+    available at https://github.com/IntelRealSense/librealsense
+
   - libuvc (e.g. github version from 2015-OCT-27)
     OPTIONAL, deprecated alternative to librealsense
     currently this works only with branch olafkaehler/master


### PR DESCRIPTION
`InputSource::RealSense2Engine` requests two streams from the first available device:
- 16 bits depth buffer
- 32 bits rgba8 color stream

Then it calibrate infiniTAM by fetching:
- depth sensor scale
- projection of depth and rgb sensor (intrinsic)
- affine transform from rgb to depth sensor (extrinsics)